### PR TITLE
Add Matchability Metric link to button group

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,6 +152,24 @@
                         arXiv
                     </span>
                 </a>
+
+                <!-- Tertiary (White) Button: Matchability Metric -->
+                <a href="https://github.com/nandometzger/Matchability" class="btn btn-primary anaglyph-button">
+                    <span class="layer cyan">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none"
+                            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
+                        </svg>
+                        Matchability Metric
+                    </span>
+                    <span class="layer red" aria-hidden="true">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none"
+                            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
+                        </svg>
+                        Matchability Metric
+                    </span>
+                </a>
             </div>
 
             <!-- Showcase Video -->


### PR DESCRIPTION
Adds a third button to the hero button group, linking to the [Matchability metric reimplementation](https://github.com/nandometzger/Matchability).

- Reuses the existing `btn btn-primary anaglyph-button` style (mirrored cyan/red layers, stroke-style GitHub icon) to match the **Paper** and **arXiv** buttons
- Positioned after **arXiv**; labeled **Matchability Metric**
- Only `index.html` changes (+18 lines; no other files touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
